### PR TITLE
fix: resolve regex failure to match ecs-user@192.168.1.1 pattern

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -85,7 +85,7 @@ type Address struct {
 	Port string
 }
 
-var addrRegex = regexp.MustCompile(`^(?:(?P<user>[\w.-_]+)@)?(?P<host>[\w.-]+)(?::(?P<port>\d+))?(?:/(?P<path>[\w/.-]+))?$`)
+var addrRegex = regexp.MustCompile(`^(?:(?P<user>[\w.\-_]+)@)?(?P<host>[\w.-]+)(?::(?P<port>\d+))?(?:/(?P<path>[\w/.-]+))?$`)
 
 func MatchAddress(addr string) (*Address, error) {
 	matches := addrRegex.FindStringSubmatch(addr)


### PR DESCRIPTION
When using `ssx ecs-user@192.168.1.1` to connect to the server, an "`invalid address`" error will be displayed.This commit has fixed this issue.
<img width="366" alt="图片" src="https://github.com/user-attachments/assets/9ef898cd-5a2c-455f-88c0-ea689f749179" />


